### PR TITLE
Replaced round(x) with floor(x+0.5)

### DIFF
--- a/posterize.lua
+++ b/posterize.lua
@@ -51,7 +51,7 @@ new = function(self)
 		vec4 effect(vec4 color, Image texture, vec2 tc, vec2 _)
 		{
 			color = Texel(texture, tc);
-			vec3 hsv = round(rgb2hsv(color.rgb) * num_bands) / num_bands;
+			vec3 hsv = floor((rgb2hsv(color.rgb) * num_bands) + 0.5) / num_bands;
 			return vec4(hsv2rgb(hsv), color.a);
 		}
 	]]


### PR DESCRIPTION
I got ERROR 'round' : no matching overloaded function found (using implicit comversion), and made this quick change to fix it. Seems to be related to the version of GLSL supported by my graphic card (I don't know much of shaders), but I believe this change does not break anything, hopefully.
