### PR TITLE
Add CRT-like Barrel Distortion

### DIFF
--- a/crt.lua
+++ b/crt.lua
@@ -1,0 +1,144 @@
+--[[
+The MIT License (MIT)
+
+Copyright (c) 2015 Daniel Oaks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]--
+
+return {
+requires = {'canvas', 'shader'},
+description = "CRT-like barrel distortion",
+
+new = function(self)
+	self.x_distortion, self.y_distortion = 0.06, 0.065
+	self.outline = {25, 25, 26}
+	self.draw_outline = true
+	self.canvas = love.graphics.newCanvas()
+	self.shader = love.graphics.newShader[[
+	// How much we distort on the x and y axis.
+	//   from 0 to 1
+	extern float x_distortion;
+	extern float y_distortion;
+
+	vec2 distort_coords(vec2 point)
+	{
+		// convert to coords we use for barrel distort function
+		//   turn 0 -> 1 into -1 -> 1
+		point.x = ((point.x * 2.0) - 1.0);
+		point.y = ((point.y * -2.0) + 1.0);
+
+		// distort
+		point.x = point.x + (point.y * point.y) * point.x * x_distortion;
+		point.y = point.y + (point.x * point.x) * point.y * y_distortion;
+
+		// convert back to coords glsl uses
+		//   turn -1 -> 1 into 0 -> 1
+		point.x = ((point.x + 1.0) / 2.0);
+		point.y = ((point.y - 1.0) / -2.0);
+
+		return point;
+	}
+
+	vec4 effect(vec4 color, Image texture, vec2 tc, vec2 _)
+	{
+		vec2 working_coords = distort_coords(tc);
+		return Texel(texture, working_coords);
+	}
+	]]
+	self.shader:send("x_distortion", self.x_distortion)
+	self.shader:send("y_distortion", self.y_distortion)
+end,
+
+distort = function(self, x, y)
+	local w = love.graphics.getWidth()
+	local h = love.graphics.getHeight()
+
+	-- turn 0 -> w/h into -1 -> 1
+	local distorted_x = (x / (w / 2)) - 1
+	local distorted_y = (y / (h / 2)) - 1
+
+	distorted_x = distorted_x + (distorted_y * distorted_y) * distorted_x * self.x_distortion
+	distorted_y = distorted_y + (distorted_x * distorted_x) * distorted_y * self.y_distortion
+
+	-- turn -1 -> 1 into 0 -> w/h
+	distorted_x = (distorted_x + 1) * (w / 2)
+	distorted_y = (distorted_y + 1) * (h / 2)
+
+	return {distorted_x, distorted_y}
+end,
+
+draw = function(self, func)
+	local c = love.graphics.getCanvas()
+	local s = love.graphics.getShader()
+	local co = {love.graphics.getColor()}
+	local b = love.graphics.getBlendMode()
+
+	-- draw scene to canvas
+	self.canvas:clear()
+	self.canvas:renderTo(func)
+
+	-- draw outline if required
+	if self.draw_outline then
+		love.graphics.setBlendMode('replace')
+		local width = love.graphics.getLineWidth()
+		love.graphics.setLineWidth(1)
+		self.canvas:renderTo(function()
+			local w = love.graphics.getWidth()
+			local h = love.graphics.getHeight()
+			love.graphics.setColor(self.outline)
+			love.graphics.line(0,0, w,0, w,h, 0,h, 0,0)
+		end)
+		love.graphics.setLineWidth(width)
+	end
+
+	-- apply shader to canvas
+	love.graphics.setColor(co)
+	love.graphics.setShader(self.shader)
+	love.graphics.setBlendMode('premultiplied')
+	love.graphics.draw(self.canvas, 0,0)
+	love.graphics.setBlendMode(b)
+
+	-- reset shader and canvas
+	love.graphics.setShader(s)
+	love.graphics.setCanvas(c)
+end,
+
+set = function(self, key, value)
+	if key == "x" then
+		assert(type(value) == "number")
+		self.x_distortion = value
+		self.shader:send("x_distortion", value)
+	elseif key == "y" then
+		assert(type(value) == "number")
+		self.y_distortion = value
+		self.shader:send("y_distortion", value)
+	elseif key == "draw_outline" then
+		assert(type(value) == "bool")
+		self.draw_outline = value
+	elseif key == "outline" then
+		assert(type(value) == "table")
+		self.outline = value
+	else
+		error("Unknown property: " .. tostring(key))
+	end
+
+	return self
+end
+}


### PR DESCRIPTION
Pretty standard barrel distortion, like ole' CRT screens. Here's how it looks:

![screen shot 2015-06-08 at 7 26 58 pm](https://cloud.githubusercontent.com/assets/251281/8031779/616a66ce-0e14-11e5-82b6-67a24e242400.png)

By default it draws a 1px outline around the outside of the screen (which gets extended everywhere there isn't colour, since the corners get pinched inwards) so the CRT effect looks much better, though this is controllable (both the colour of the border, or just disabling it entirely).

It also provides a `shader:distort(x, y)` function so that you can take something like mouse coords and draw a circle on the screen where the mouse is, given the current distortion. Example code:

``` lua
love.graphics.setColor(200,200,200,200)
x, y = unpack(crt:distort(love.mouse.getPosition()))
love.graphics.circle("line", x, y, 10, 10)
```

This could also be useful for things like mouse positions for menu systems, if the menu is actually on the distorted surface.

Similar to #9, I've just got the `demo` branch diff here. If you'd like me to PR that change too, just let me know.
http://pastebin.com/raw.php?i=t7ZKnywT

``` diff
diff --git a/main.lua b/main.lua
index 17a5e1a..02d42bb 100644
--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,7 @@ local effect_names = {
    "separate_chroma",
    "vignette",
    "dmg",
+   "crt",
 }
 local current, effects

@@ -136,6 +137,16 @@ options = {
            return ("palette = %s"):format(math.floor(o.palette.value))
        end
    },
+   crt = {opts = {"x", "y", "red", "green", "blue"},
+       x = {value = 0.06, min = 0, max = 1, onHit = setval("crt", "x")},
+       y = {value = 0.065, min = 0, max = 1, onHit = setval("crt", "y")},
+       red = {value = 25, min = 0, max = 255, onHit = setrgb("crt", "outline")},
+       green = {value = 25, min = 0, max = 255, onHit = setrgb("crt", "outline")},
+       blue = {value = 26, min = 0, max = 255, onHit = setrgb("crt", "outline")},
+       dump = function(o)
+           return ("x = %.04f, y = %.04f, outline = {%d,%d,%d}"):format(o.x.value, o.y.value, o.red.value, o.green.value, o.blue.value)
+       end
+   },
 }

 function love.update(dt)
```

**edit:** Would it be better to rename this effect `barrel` or something like that, because CRT would actually be a combination of a few different effects.
