### PR TITLE
Fix "scanline_height" key to "line_height"

### DIFF
--- a/scanlines.lua
+++ b/scanlines.lua
@@ -97,7 +97,7 @@ new = function(self)
 	self.shader:send("pixel_size", self._pixel_size)
 	self.shader:send("opacity", self._opacity)
 	self.shader:send("center_fade", self._center_fade)
-	self.shader:send("scanline_height", self._line_height)
+	self.shader:send("line_height", self._line_height)
 end,
 
 draw = function(self, func, ...)


### PR DESCRIPTION
I resolved a naming conflict in which the key name for "line_height"of the scanlines shader was incorrectly named "scanline_height," resulting in an error thrown in execution. The key has been renamed as "line_height" and thus would be used in Lua as follows:

```
local scanlines = shine.scanlines()
scanlines.parameter = {pixel_size = 3, opacity = 0.3, center_fade = 0.44, line_height = 0.35}
```
