### PR TITLE
No floating point suffixes for shaders (iOS fix)

### DIFF
--- a/boxblur.lua
+++ b/boxblur.lua
@@ -21,13 +21,13 @@ return function(moonshine)
     extern vec2 direction;
     extern number radius;
     vec4 effect(vec4 color, Image texture, vec2 tc, vec2 _) {
-      vec4 c = vec4(0.0f);
+      vec4 c = vec4(0.0);
 
-      for (float i = -radius; i <= radius; i += 1.0f)
+      for (float i = -radius; i <= radius; i += 1.0)
       {
         c += Texel(texture, tc + i * direction);
       }
-      return c / (2.0f * radius + 1.0f) * color;
+      return c / (2.0 * radius + 1.0) * color;
     }]]
 
   local setters = {}

--- a/colorgradesimple.lua
+++ b/colorgradesimple.lua
@@ -19,7 +19,7 @@ return function(moonshine)
   local shader = love.graphics.newShader[[
     extern vec3 factors;
     vec4 effect(vec4 color, Image texture, vec2 tc, vec2 _) {
-      return vec4(factors, 1.0f) * Texel(texture, tc) * color;
+      return vec4(factors, 1.0) * Texel(texture, tc) * color;
     }]]
 
   local setters = {}

--- a/crt.lua
+++ b/crt.lua
@@ -16,7 +16,7 @@ PERFORMANCE OF THIS SOFTWARE.
 ]]--
 
 return function(moonshine)
-  -- Barrel distortion adapted from Daniel Oaks (see commit cef01b67d)
+  -- Barrel distortion adapted from Daniel Oaks (see commit cef01b67fd)
   -- Added feather to mask out outside of distorted texture
   local distortionFactor
   local shader = love.graphics.newShader[[

--- a/crt.lua
+++ b/crt.lua
@@ -16,7 +16,7 @@ PERFORMANCE OF THIS SOFTWARE.
 ]]--
 
 return function(moonshine)
-  -- Barrel distortion adapted from Daniel Oaks (see commit cef01b67fd)
+  -- Barrel distortion adapted from Daniel Oaks (see commit cef01b67d)
   -- Added feather to mask out outside of distorted texture
   local distortionFactor
   local shader = love.graphics.newShader[[

--- a/desaturate.lua
+++ b/desaturate.lua
@@ -21,7 +21,7 @@ return function(moonshine)
     extern number strength;
     vec4 effect(vec4 color, Image texture, vec2 tc, vec2 _) {
       color = Texel(texture, tc);
-      number luma = dot(vec3(0.299f, 0.587f, 0.114f), color.rgb);
+      number luma = dot(vec3(0.299, 0.587, 0.114), color.rgb);
       return mix(color, tint * luma, strength);
     }]]
 

--- a/fastgaussianblur.lua
+++ b/fastgaussianblur.lua
@@ -64,7 +64,7 @@ local function build_shader(taps, offset, offset_type, sigma)
 
   local norm = 0
   if #g_weights % 2 == 0 then
-    code[#code+1] =  'vec4 c = vec4( 0.0f );'
+    code[#code+1] =  'vec4 c = vec4( 0.0 );'
   else
     local weight = g_weights[1]
     norm = norm + weight

--- a/gaussianblur.lua
+++ b/gaussianblur.lua
@@ -15,7 +15,7 @@ local function resetShader(sigma)
   local code = {[[
     extern vec2 direction;
     vec4 effect(vec4 color, Image texture, vec2 tc, vec2 _)
-    { vec4 c = vec4(0.0f);
+    { vec4 c = vec4(0.0);
   ]]}
   local blur_line = "c += vec4(%f) * Texel(texture, tc + vec2(%f) * direction);"
 

--- a/glow.lua
+++ b/glow.lua
@@ -25,7 +25,7 @@ local function make_blur_shader(sigma)
   local code = {[[
     extern vec2 direction;
     vec4 effect(vec4 color, Image texture, vec2 tc, vec2 _) {
-      vec4 c = vec4(0.0f);
+      vec4 c = vec4(0.0);
   ]]}
   local blur_line = "c += vec4(%f) * Texel(texture, tc + vec2(%f) * direction);"
 

--- a/vignette.lua
+++ b/vignette.lua
@@ -27,7 +27,7 @@ return function(moonshine)
       number aspect = love_ScreenSize.x / love_ScreenSize.y;
       aspect = max(aspect, 1.0 / aspect); // use different aspect when in portrait mode
       number v = 1.0 - smoothstep(radius, radius-softness,
-                                  length((tc - vec2(0.5f)) * aspect));
+                                  length((tc - vec2(0.5)) * aspect));
       return mix(Texel(tex, tc), color, v*opacity);
     }]]
 


### PR DESCRIPTION
Hi! Thanks for the great lib.

When I attempt to use it on iOS, I get an error about the shader compiler there not supporting the 'f' floating point suffixes that are in the various shaders. So I removed them. I've tested it with this change on macOS and iOS, both work.

Let me know if you have any comments!

-nikki