### PR TITLE
(love 11.0) Use normalized colors; fix broken sketch and filmgrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ moonshine.effects.desaturate
 
 Name | Type | Default
 -----|------|--------
-tint | color / table of numbers | {255,255,255}
+tint | color / table of numbers | {1,1,1}
 strength | number between 0 and 1 | 0.5
 
 
@@ -312,7 +312,7 @@ DMG ships with 7 palettes:
 7. `pocket`
 
 Custom palettes must be in the format `{{R,G,B}, {R,G,B}, {R,G,B}, {R,G,B}}`,
-where `R`, `G`, and `B` are numbers between `0` and `255`.
+where `R`, `G`, and `B` are numbers between `0` and `1`.
 
 
 <a name="effect-fastgaussianblur"></a>

--- a/desaturate.lua
+++ b/desaturate.lua
@@ -29,10 +29,11 @@ return function(moonshine)
 
   setters.tint = function(c)
     assert(type(c) == "table" and #c == 3, "Invalid value for `tint'")
+    assert(c[1] <= 1, "Colors should be normalized in [0,1]")
     shader:send("tint", {
-      (tonumber(c[1]) or 0) / 255,
-      (tonumber(c[2]) or 0) / 255,
-      (tonumber(c[3]) or 0) / 255,
+      (tonumber(c[1]) or 0),
+      (tonumber(c[2]) or 0),
+      (tonumber(c[3]) or 0),
       1
     })
   end
@@ -41,7 +42,7 @@ return function(moonshine)
     shader:send("strength", math.max(0, math.min(1, tonumber(v) or 0)))
   end
 
-  local defaults = {tint = {255,255,255}, strength = 0.5}
+  local defaults = {tint = {1,1,1}, strength = 0.5}
 
   return moonshine.Effect{
     name = "desaturate",

--- a/filmgrain.lua
+++ b/filmgrain.lua
@@ -18,7 +18,7 @@ PERFORMANCE OF THIS SOFTWARE.
 return function(moonshine)
   local noisetex = love.image.newImageData(256,256)
   noisetex:mapPixel(function()
-    local l = love.math.random() * 255
+    local l = love.math.random()
     return l,l,l,l
   end)
   noisetex = love.graphics.newImage(noisetex)

--- a/scanlines.lua
+++ b/scanlines.lua
@@ -57,10 +57,11 @@ return function(moonshine)
   end
   setters.color = function(c)
     assert(type(c) == "table" and #c == 3, "Invalid value for `color'")
+    assert(c[1] <= 1, "Colors should be normalized in [0,1]")
     shader:send("color", {
-      (tonumber(c[1]) or defaults.color[0]) / 255,
-      (tonumber(c[2]) or defaults.color[1]) / 255,
-      (tonumber(c[3]) or defaults.color[2]) / 255
+      (tonumber(c[1]) or defaults.color[0]),
+      (tonumber(c[2]) or defaults.color[1]),
+      (tonumber(c[3]) or defaults.color[2])
     })
   end
 

--- a/scanlines.lua
+++ b/scanlines.lua
@@ -59,9 +59,9 @@ return function(moonshine)
     assert(type(c) == "table" and #c == 3, "Invalid value for `color'")
     assert(c[1] <= 1, "Colors should be normalized in [0,1]")
     shader:send("color", {
-      (tonumber(c[1]) or defaults.color[0]),
-      (tonumber(c[2]) or defaults.color[1]),
-      (tonumber(c[3]) or defaults.color[2])
+      (tonumber(c[1]) or defaults.color[1]),
+      (tonumber(c[2]) or defaults.color[2]),
+      (tonumber(c[3]) or defaults.color[3])
     })
   end
 

--- a/sketch.lua
+++ b/sketch.lua
@@ -26,7 +26,7 @@ SOFTWARE.
 return function(moonshine)
   local noisetex = love.image.newImageData(256,256)
   noisetex:mapPixel(function()
-    return love.math.random() * 255,love.math.random() * 255, 0, 0
+    return love.math.random(),love.math.random(), 0, 0
   end)
   noisetex = love.graphics.newImage(noisetex)
   noisetex:setWrap ("repeat", "repeat")

--- a/vignette.lua
+++ b/vignette.lua
@@ -37,10 +37,11 @@ return function(moonshine)
   end
   setters.color = function(c)
     assert(type(c) == "table" and #c == 3, "Invalid value for `color'")
+    assert(c[1] <= 1, "Colors should be normalized in [0,1]")
     shader:send("color", {
-      (tonumber(c[1]) or 0) / 255,
-      (tonumber(c[2]) or 0) / 255,
-      (tonumber(c[3]) or 0) / 255,
+      (tonumber(c[1]) or 0),
+      (tonumber(c[2]) or 0),
+      (tonumber(c[3]) or 0),
       1
     })
   end


### PR DESCRIPTION
Update to love 11.0 colour format where all colours are normalized in [0,1].

Also fix some invalid indexing.

While some effects will continue to work so long as users pass 255 color values (desaturate, scanlines, vignette), the others are broken in love 11.0 without this change (sketch, filmgrain).

This change would break behaviour for use with love 0.10. Not sure how you want to deal with that. Maybe make a pre-11.0 tag?

## sketch
![image](https://user-images.githubusercontent.com/43559/147736323-063b4119-e4e1-4b89-86e0-8d46f1dde826.png)

Completely broken -- nearly no pixels modified.

## filmgrain

![image](https://user-images.githubusercontent.com/43559/147736382-fa273870-ca13-4c33-aab8-e713200e3cc3.png)

Very broken -- few grains visible.

## Test

I flipped through the effects in the demo and they all seem to work now (or at least have some effect).